### PR TITLE
SSL証明書をdevelopment環境でのみ適用

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -16,10 +16,12 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
 # port ENV.fetch("PORT") { 3000 }
-ssl_bind "0.0.0.0", "3000", {
-  cert: "config/certs/localhost.pem",
-  key:  "config/certs/localhost-key.pem"
+if ENV.fetch('RAILS_ENV') { 'development' } == 'development'
+  ssl_bind '0.0.0.0', '3000', {
+    cert: 'config/certs/localhost.pem',
+    key: 'config/certs/localhost-key.pem'
 }
+end
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
- fly deproy時にconfig/certs以下のファイルの読み込みに失敗したため修正
- 以下のサイトを参考にdevelopment環境で証明書と鍵を読み込む設定に変更
https://qiita.com/A__Matsuda/items/775bd86ad31b07a153c7