### PR TITLE
フラッシュメッセージが一部出ていないエラーの修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  add_flash_types :success, :info, :warning, :danger
+  
   before_action :login_required
 
   helper_method :current_user


### PR DESCRIPTION
フラッシュメッセージを許可しているキーがnotice, alertのみだった

https://qiita.com/Yama-to/items/4d19a714d8bf5bfbabdd#%E3%83%95%E3%83%A9%E3%83%83%E3%82%B7%E3%83%A5%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8%E3%81%AE%E3%82%AD%E3%83%BC%E3%82%92%E8%A8%B1%E5%8F%AF%E3%81%99%E3%82%8B%E8%A8%98%E8%BF%B0