### PR TITLE
Notificationsテーブル設計　enum設定

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,3 +1,5 @@
 class Notification < ApplicationRecord
   belongs_to :task
+
+  enum status: { send: 0, done: 1}
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,5 +1,5 @@
 class Notification < ApplicationRecord
   belongs_to :task
 
-  enum status: { send: 0, done: 1}
+  enum status: { send: 0, done: 1 }
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -19,3 +19,7 @@ ja:
         short: '短い'
         middle: 'ちょっと長い'
         long: 'かなり長い'
+    notification:
+      status:
+        send: '送信済'
+        done: '実行済'


### PR DESCRIPTION
Notificationsテーブル
statusカラムにenumで「送信済み、実施済み」の設定を追加